### PR TITLE
feat: add get_internal_type method

### DIFF
--- a/nanoid_field/fields.py
+++ b/nanoid_field/fields.py
@@ -22,3 +22,6 @@ class NanoidField(models.CharField):
 
     def nanoid(self):
         return generate(self.alphabet, self.max_length)
+
+    def db_type(self, connection):
+        return 'varchar({})'.format(self.max_length)

--- a/nanoid_field/fields.py
+++ b/nanoid_field/fields.py
@@ -23,5 +23,5 @@ class NanoidField(models.CharField):
     def nanoid(self):
         return generate(self.alphabet, self.max_length)
 
-    def db_type(self, connection):
-        return 'varchar({})'.format(self.max_length)
+    def get_internal_type(self):
+        return "CharField"


### PR DESCRIPTION
@goztrk 
## Description

I've added some code to address an issue where referencing a `NanoidField` set as a primary key with a foreign key results in an `invalid input syntax for type bigint` error.