### PR TITLE
Add deconstruct

### DIFF
--- a/nanoid_field/fields.py
+++ b/nanoid_field/fields.py
@@ -25,3 +25,11 @@ class NanoidField(models.CharField):
 
     def get_internal_type(self):
         return "CharField"
+
+    def deconstruct(self):
+        name, path, args, kwargs = super().deconstruct()
+        kwargs['alphabet'] = self.alphabet
+        kwargs['max_length'] = self.max_length
+        kwargs.pop('default', None)
+
+        return name, path, args, kwargs


### PR DESCRIPTION
The current implementation is causing Django to detect a migration each time `makemigrations` is run as the `deconstruct` method is missing:

> If you haven’t added any extra options on top of the field you inherited from, then there’s no need to write a new deconstruct() method. If, however, you’re changing the arguments passed in __init__() (like we are in HandField), you’ll need to supplement the values being passed.

https://docs.djangoproject.com/en/5.0/howto/custom-model-fields/#field-deconstruction